### PR TITLE
feat: adding additional ABI fetching option

### DIFF
--- a/apps/tx-builder/src/lib/getAbi.ts
+++ b/apps/tx-builder/src/lib/getAbi.ts
@@ -171,6 +171,8 @@ const getGatewayBaseUrl = (chain: string) => {
 
 const getScanAPIBaseURL = (chain: string) => {
   switch (chain) {
+    case SUPPORTED_CHAINS.CASCADIA_TESTNET:
+      return 'https://explorer.cascadia.foundation'
     case SUPPORTED_CHAINS.LINEA:
       return 'https://api.lineascan.build'
     case SUPPORTED_CHAINS.LINEA_TESTNET:

--- a/apps/tx-builder/src/lib/getAbi.ts
+++ b/apps/tx-builder/src/lib/getAbi.ts
@@ -176,9 +176,7 @@ const getScanAPIBaseURL = (chain: string) => {
     case SUPPORTED_CHAINS.LINEA_TESTNET:
       return 'https://api-testnet.lineascan.build'
     default:
-      throw new Error(
-        `[getScanAPIBaseURL]: There is no scan API for ${chain}, therefore we cannot get the contract abi from it.`,
-      )
+      return
   }
 }
 

--- a/apps/tx-builder/src/lib/getAbi.ts
+++ b/apps/tx-builder/src/lib/getAbi.ts
@@ -5,6 +5,7 @@ enum PROVIDER {
   SOURCIFY = 1,
   GATEWAY = 2,
   BLOCKSCOUT = 3,
+  SCANAPI = 4,
 }
 
 type SourcifyResponse = {
@@ -24,6 +25,8 @@ const getProviderURL = (chain: string, address: string, urlProvider: PROVIDER): 
       return `${getGatewayBaseUrl(chain)}/v1/chains/${chain}/contracts/${address}`
     case PROVIDER.BLOCKSCOUT:
       return `https://blockscout.com/${chain}/api?module=contract&action=getabi&address=${address}`
+    case PROVIDER.SCANAPI:
+      return `${getScanAPIBaseURL(chain)}/api?module=contract&action=getabi&address=${address}`
     default:
       throw new Error('The Provider is not supported')
   }
@@ -166,6 +169,19 @@ const getGatewayBaseUrl = (chain: string) => {
   }
 }
 
+const getScanAPIBaseURL = (chain: string) => {
+  switch (chain) {
+    case SUPPORTED_CHAINS.LINEA:
+      return 'https://api.lineascan.build'
+    case SUPPORTED_CHAINS.LINEA_TESTNET:
+      return 'https://api-testnet.lineascan.build'
+    default:
+      throw new Error(
+        `[getScanAPIBaseURL]: There is no scan API for ${chain}, therefore we cannot get the contract abi from it.`,
+      )
+  }
+}
+
 const getAbiFromSourcify = async (address: string, chainId: string): Promise<any> => {
   const { data } = await axios.get<SourcifyResponse[]>(
     getProviderURL(chainId, address, PROVIDER.SOURCIFY),
@@ -211,6 +227,20 @@ const getAbiFromBlockscout = async (address: string, chainId: string): Promise<a
   throw new Error('Contract found but could not found ABI using Blockscout')
 }
 
+const getABIFromScanAPI = async (address: string, chainId: string): Promise<any> => {
+  const { data } = await axios.get(getProviderURL(chainId, address, PROVIDER.SCANAPI), {
+    timeout: DEFAULT_TIMEOUT,
+  })
+  // We need to check if the abi is present in the response because it's possible
+  // That the transaction service just stores the contract and returns 200 without querying for the abi
+  // (or querying for the abi failed)
+  if (data && data.message === 'OK' && data.result) {
+    return JSON.parse(data.result)
+  }
+
+  throw new Error('Contract found but ABI is missing when using API service')
+}
+
 const getAbi = async (address: string, chainInfo: ChainInfo): Promise<any> => {
   let abi
   try {
@@ -218,6 +248,7 @@ const getAbi = async (address: string, chainInfo: ChainInfo): Promise<any> => {
       getAbiFromSourcify(address, chainInfo.chainId),
       getAbiFromGateway(address, chainInfo.chainId),
       getAbiFromBlockscout(address, chainInfo.chainId),
+      getABIFromScanAPI(address, chainInfo.chainId),
     ])
   } catch {
     abi = null


### PR DESCRIPTION
## What it solves
Absent ABI for networks that do not have blockscout, sourcify support or their contract ABIs are not present in gateway.
## How this PR fixes it
By adding additional configuration of API scan services the ABI can be fetched for any verified contract on that explorer.

## How to test it
- Run tx builder locally
- Add safe app to any safe (currently can be tested for 59140 and 59144 networks)
- Put the verified contract address. If it is a proxy - the modal window should appear to select the correct ABI

## Screenshots
![modal for proxy](https://gateway.pinata.cloud/ipfs/Qmc8asRxuU4mFYLycxYA5nMXdPUumg7oFfdk3m8gjGsMQ6)
![fetched ABI](https://gateway.pinata.cloud/ipfs/QmefANCwcWcsWfWjbgpgzGufFqBFR9A1YrqyhEnaQuAcBm)